### PR TITLE
build: Add eslint-import-resolver-typescript dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "@hipo/eslint-config-typescript",
+  "version": "1.0.1",
+  "lockfileVersion": 1
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hipo/eslint-config-typescript",
-  "version": "1.0.1",
+  "version": "1.2.0",
   "description": "Hipo's shareable ESLint configurations for TypeScript",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
   "homepage": "https://github.com/Hipo/eslint-config-hipo-typescript#readme",
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.21.0",
-    "@typescript-eslint/parser": "^4.21.0"
+    "@typescript-eslint/parser": "^4.26.0",
+    "eslint-import-resolver-typescript": "^2.4.0",
+    "eslint-plugin-import": "^2.23.4"
   }
 }


### PR DESCRIPTION
- Add `eslint-import-resolver-typescript`as `peerDependency`
- Bump up `@typescript-eslint/parse` to `4.26.0` version
- This plugin requires some changes on the `.eslintrc`, reference: [eslint-import-resolver-typescript](https://github.com/alexgorbatchev/eslint-import-resolver-typescript#readme)

Related Issue: https://github.com/Hipo/eslint-config-hipo-typescript/issues/3